### PR TITLE
Pr version150 semivers

### DIFF
--- a/WatsonIoT/src/config.h
+++ b/WatsonIoT/src/config.h
@@ -4,7 +4,7 @@
 //#define OPENEEW_ACTIVATION_ENDPOINT "https://openeew-devicemgmt.mybluemix.net/activation?ver=1"
 #define OPENEEW_ACTIVATION_ENDPOINT "https://device-mgmt.openeew.com/activation?ver=1"
 // VERSION uses convention semver.org
-//  1.3.9 < 1.4.0 < 1.4.1-alpha1 < 1.4.1-alpha2 < 1.4.1
+//  1.3.9 < 1.4.0 < 1.4.1-alpha.1 < 1.4.1-alpha.2 < 1.4.1-beta.1 < 1.4.1
 #define OPENEEW_FIRMWARE_VERSION    "1.5.0"
 
 // Run this firmware with a MQTT Broker on a local subnet


### PR DESCRIPTION
Correction for semiver.org comparison . Should be merging to openeew/openeew-firmware (version150)

It turns out I didn't read the spec in semiver.org in detail and the upgrade attempt failed with 1.5.1-alpha1 
Seems like semivers says it should be 1.5.1-alpha.1
My mistake
Sorry can't try this out yet to make sure it works, but updated the comments per the spec.
Hopefully -s gives the right intent.   Gritkraken took over part of the config when I tried it.

Log of attempt is here 
Wed Apr 14 21:26:09 2021

Contacting the OpenEEW Device Activation Endpoint :
https://device-mgmt.openeew.com/activation?ver=1
Sending Device Activation : {"macaddress":"A8032A4DCCCC","firmware_device":"1.5.0"}
HTTP Response code: 200
HTTP post response payload: {"org":"7p7xwk","firmware_latest":"1.5.1-alpha1","firmware_ota_url":"https://openeew-devicemgmt.mybluemix.net/firmware/firmware-1.5.1-alpha1.bin"}
OpenEEW Device Activation directs MQTT data from this sensor to :7p7xwk
Invalid semver string
d:7p7xwk:OpenEEW:A8032A4DCCCC