### PR TITLE
Version151

### DIFF
--- a/WatsonIoT/src/config.h
+++ b/WatsonIoT/src/config.h
@@ -5,7 +5,7 @@
 #define OPENEEW_ACTIVATION_ENDPOINT "https://device-mgmt.openeew.com/activation?ver=1"
 // VERSION uses convention semver.org
 //  1.3.9 < 1.4.0 < 1.4.1-alpha.1 < 1.4.1-alpha.2 < 1.4.1-beta.1 < 1.4.1
-#define OPENEEW_FIRMWARE_VERSION    "1.5.0"
+#define OPENEEW_FIRMWARE_VERSION    "1.5.1"
 
 // Run this firmware with a MQTT Broker on a local subnet
 // One way of setting up a local subnet MQTT Broker, see

--- a/WatsonIoT/src/dlcert.h
+++ b/WatsonIoT/src/dlcert.h
@@ -1,0 +1,96 @@
+#define DOWNLOAD_OPENEEW_COM_PEM                                        \
+"-----BEGIN CERTIFICATE----- \r\n"                                      \
+"MIIElDCCA3ygAwIBAgIQAf2j627KdciIQ4tyS8+8kTANBgkqhkiG9w0BAQsFADBh\r\n"  \
+"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\r\n"  \
+"MIIFLTCCBBWgAwIBAgISBNTqFCqim9pOdUj2vAw6xj3MMA0GCSqGSIb3DQEBCwUA\r\n"  \
+"MDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD\r\n"  \
+"EwJSMzAeFw0yMTA0MTYxODU1MzJaFw0yMTA3MTUxODU1MzJaMB8xHTAbBgNVBAMT\r\n"  \
+"FGRvd25sb2FkLm9wZW5lZXcuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\r\n"  \
+"CgKCAQEAptjq0YPmzpqzcmJC51nZoe4BIQxhxjHZuHxODxUtkoIfMviK9vgKmr9J\r\n"  \
+"z45ODCE7c5K8Iy+x+1Mqv8gvzvowSoC+CpzVhV3ni3D00a7x70i9xQRtProvvupL\r\n"  \
+"c8APXOgTIbo8/br7AC45PidLUawj0rhIk+QQutkzwsCYLUA2OX2wGbTFIPTdvWgH\r\n"  \
+"p/EMgfv1CLxX6x8j0pZ406Gal+v3c9WBaX9PdzHpsVa6HXiMBhc5+mjMHBqPm/05\r\n"  \
+"+4O/gHACPINDGYzS2qwFQrlB4O07wV0q4vkxjjnj7Y5ctX+QGMZzESHmj+JBCXXr\r\n"  \
+"MMTgPH7VGzGJNeEiuYMpRNXjdSWPwQIDAQABo4ICTjCCAkowDgYDVR0PAQH/BAQD\r\n"  \
+"AgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAA\r\n"  \
+"MB0GA1UdDgQWBBRPoa/7OPDke9kP4S7J2L5pgtWOBjAfBgNVHSMEGDAWgBQULrMX\r\n"  \
+"t1hWy65QCUDmH6+dixTCxjBVBggrBgEFBQcBAQRJMEcwIQYIKwYBBQUHMAGGFWh0\r\n"  \
+"dHA6Ly9yMy5vLmxlbmNyLm9yZzAiBggrBgEFBQcwAoYWaHR0cDovL3IzLmkubGVu\r\n"  \
+"Y3Iub3JnLzAfBgNVHREEGDAWghRkb3dubG9hZC5vcGVuZWV3LmNvbTBMBgNVHSAE\r\n"  \
+"RTBDMAgGBmeBDAECATA3BgsrBgEEAYLfEwEBATAoMCYGCCsGAQUFBwIBFhpodHRw\r\n"  \
+"Oi8vY3BzLmxldHNlbmNyeXB0Lm9yZzCCAQMGCisGAQQB1nkCBAIEgfQEgfEA7wB1\r\n"  \
+"AJQgvB6O1Y1siHMfgosiLA3R2k1ebE+UPWHbTi9YTaLCAAABeNxAuYIAAAQDAEYw\r\n"  \
+"RAIgcNvu+CcmFewqn7gwYJ2m+/zstVuRzl12X3KzzLLi/aQCIGPp01pnlIOx2ZE1\r\n"  \
+"8keWii8UNCJgax+wTMLW34pXAdRdAHYA9lyUL9F3MCIUVBgIMJRWjuNNExkzv98M\r\n"  \
+"LyALzE7xZOMAAAF43EC5qgAABAMARzBFAiBx1tSxC/LgyUg+PdTocZhIsB35qJLr\r\n"  \
+"pJ2zzrjjj31h1QIhAL2MK7G0WuUYn/aZ0ISyG8CKJNCb4Xe8FUXSP3qvbPztMA0G\r\n"  \
+"CSqGSIb3DQEBCwUAA4IBAQAA+PyxtYwIMXxbVX7/FHsNDBHCt5X49PYUpnyUExnV\r\n"  \
+"+LoryaIM9P0KptsB7Wd8qjZ+2MLsV5RQV9vqmU+6XKcJ1GHI3c7JYAjVaFzR6jy+\r\n"  \
+"VZqyTIn43m6ZoIPlyAEKgYJPHB8lEOmkQt7xLn7+BhAA1bx3Gvn7aAIyRcjj+Cje\r\n"  \
+"VdgQ+1EclJerxD5kIUrluFEXoywDaYse1jsYe6uOsz5pBZVCkTLEAQcoK0YlRmPG\r\n"  \
+"VDtAmGW9895qTUxzsdwCRT8tAlhye7KXMh3Tcsx+sVeQIlYTcLMcDhuQOPjcG38S\r\n"  \
+"xWKbwqgk8VNoz4JENI3Lu/oN7CurTaV5HggFzSsyoo0o\r\n"                      \
+"-----END CERTIFICATE----- \r\n"                                        \
+"-----BEGIN CERTIFICATE----- \r\n"                                      \
+"MIIFFjCCAv6gAwIBAgIRAJErCErPDBinU/bWLiWnX1owDQYJKoZIhvcNAQELBQAw\r\n"  \
+"TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\r\n"  \
+"cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMjAwOTA0MDAwMDAw\r\n"  \
+"WhcNMjUwOTE1MTYwMDAwWjAyMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg\r\n"  \
+"RW5jcnlwdDELMAkGA1UEAxMCUjMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\r\n"  \
+"AoIBAQC7AhUozPaglNMPEuyNVZLD+ILxmaZ6QoinXSaqtSu5xUyxr45r+XXIo9cP\r\n"  \
+"R5QUVTVXjJ6oojkZ9YI8QqlObvU7wy7bjcCwXPNZOOftz2nwWgsbvsCUJCWH+jdx\r\n"  \
+"sxPnHKzhm+/b5DtFUkWWqcFTzjTIUu61ru2P3mBw4qVUq7ZtDpelQDRrK9O8Zutm\r\n"  \
+"NHz6a4uPVymZ+DAXXbpyb/uBxa3Shlg9F8fnCbvxK/eG3MHacV3URuPMrSXBiLxg\r\n"  \
+"Z3Vms/EY96Jc5lP/Ooi2R6X/ExjqmAl3P51T+c8B5fWmcBcUr2Ok/5mzk53cU6cG\r\n"  \
+"/kiFHaFpriV1uxPMUgP17VGhi9sVAgMBAAGjggEIMIIBBDAOBgNVHQ8BAf8EBAMC\r\n"  \
+"AYYwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMBIGA1UdEwEB/wQIMAYB\r\n"  \
+"Af8CAQAwHQYDVR0OBBYEFBQusxe3WFbLrlAJQOYfr52LFMLGMB8GA1UdIwQYMBaA\r\n"  \
+"FHm0WeZ7tuXkAXOACIjIGlj26ZtuMDIGCCsGAQUFBwEBBCYwJDAiBggrBgEFBQcw\r\n"  \
+"AoYWaHR0cDovL3gxLmkubGVuY3Iub3JnLzAnBgNVHR8EIDAeMBygGqAYhhZodHRw\r\n"  \
+"Oi8veDEuYy5sZW5jci5vcmcvMCIGA1UdIAQbMBkwCAYGZ4EMAQIBMA0GCysGAQQB\r\n"  \
+"gt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCFyk5HPqP3hUSFvNVneLKYY611TR6W\r\n"  \
+"PTNlclQtgaDqw+34IL9fzLdwALduO/ZelN7kIJ+m74uyA+eitRY8kc607TkC53wl\r\n"  \
+"ikfmZW4/RvTZ8M6UK+5UzhK8jCdLuMGYL6KvzXGRSgi3yLgjewQtCPkIVz6D2QQz\r\n"  \
+"CkcheAmCJ8MqyJu5zlzyZMjAvnnAT45tRAxekrsu94sQ4egdRCnbWSDtY7kh+BIm\r\n"  \
+"lJNXoB1lBMEKIq4QDUOXoRgffuDghje1WrG9ML+Hbisq/yFOGwXD9RiX8F6sw6W4\r\n"  \
+"avAuvDszue5L3sz85K+EC4Y/wFVDNvZo4TYXao6Z0f+lQKc0t8DQYzk1OXVu8rp2\r\n"  \
+"yJMC6alLbBfODALZvYH7n7do1AZls4I9d1P4jnkDrQoxB3UqQ9hVl3LEKQ73xF1O\r\n"  \
+"yK5GhDDX8oVfGKF5u+decIsH4YaTw7mP3GFxJSqv3+0lUFJoi5Lc5da149p90Ids\r\n"  \
+"hCExroL1+7mryIkXPeFM5TgO9r0rvZaBFOvV2z0gp35Z0+L4WPlbuEjN/lxPFin+\r\n"  \
+"HlUjr8gRsI3qfJOQFy/9rKIJR0Y/8Omwt/8oTWgy1mdeHmmjk7j1nYsvC9JSQ6Zv\r\n"  \
+"MldlTTKB3zhThV1+XWYp6rjd5JW1zbVWEkLNxE7GJThEUG3szgBVGP7pSWTUTsqX\r\n"  \
+"nLRbwHOoq7hHwg==\r\n"                                                  \
+"-----END CERTIFICATE----- \r\n"                                        \
+"-----BEGIN CERTIFICATE----- \r\n"                                      \
+"MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\r\n"  \
+"TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\r\n"  \
+"cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\r\n"  \
+"WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\r\n"  \
+"ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\r\n"  \
+"MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\r\n"  \
+"h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\r\n"  \
+"0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\r\n"  \
+"A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\r\n"  \
+"T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\r\n"  \
+"B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\r\n"  \
+"B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\r\n"  \
+"KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\r\n"  \
+"OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\r\n"  \
+"jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\r\n"  \
+"qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\r\n"  \
+"rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\r\n"  \
+"HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\r\n"  \
+"hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\r\n"  \
+"ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\r\n"  \
+"3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\r\n"  \
+"NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\r\n"  \
+"ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\r\n"  \
+"TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\r\n"  \
+"jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\r\n"  \
+"oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\r\n"  \
+"4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\r\n"  \
+"mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\r\n"  \
+"emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\r\n"  \
+"-----END CERTIFICATE-----\r\n"
+
+const char DownLoadOpenEEWPem[] = DOWNLOAD_OPENEEW_COM_PEM;

--- a/WatsonIoT/src/main.cpp
+++ b/WatsonIoT/src/main.cpp
@@ -62,7 +62,6 @@ PubSubClient mqtt(MQTT_HOST, MQTT_PORT, callback, wifiClient);
 
 // Activation
 bool OpenEEWDeviceActivation();
-bool LegacyFirmwareVersionCheck( char *, String );
 bool FirmwareVersionCheck( char *, String );
 void SetTimeESP32();
 void SendLiveData2Cloud();
@@ -357,95 +356,6 @@ void callback(char* topic, byte* payload, unsigned int length) {
 }
 
 
-
-bool LegacyFirmwareVersionCheck( char *firmware_latest, String firmware_ota_url ) {
-  semver_t current_version = {};
-  semver_t latest_version = {};
-  char VersionCheck[55];
-  bool bFirmwareUpdateRequiredOTA = false;
-
-  if (semver_parse(OPENEEW_FIRMWARE_VERSION, &current_version)
-    || semver_parse(firmware_latest, &latest_version)) {
-    Serial.println("Invalid semver string");
-    return false;
-  }
-
-  int resolution = semver_compare(latest_version, current_version);
-
-  if (resolution == 0) {
-    snprintf(VersionCheck,54,"Version %s is equal to: %s", firmware_latest, OPENEEW_FIRMWARE_VERSION);
-  }
-  else if (resolution == -1) {
-    snprintf(VersionCheck,54,"Version %s is lower than: %s", firmware_latest, OPENEEW_FIRMWARE_VERSION);
-  }
-  else {
-    snprintf(VersionCheck,54,"Version %s is higher than: %s", firmware_latest, OPENEEW_FIRMWARE_VERSION);
-    bFirmwareUpdateRequiredOTA = true;
-  }
-  Serial.println(VersionCheck);
-
-  if( bFirmwareUpdateRequiredOTA ) {
-    // OTA upgrade is required
-    Serial.println("An OTA upgrade is required. Download the new OpenEEW firmware :");
-    Serial.println(firmware_ota_url);
-    // Launch an OTA upgrade
-    NeoPixelStatus( LED_FIRMWARE_OTA ); // blink magenta
-
-    if( SPIFFS.begin(false) ) {
-      Serial.printf("Opening Server PEM Chain : %s\r\n", BLUEMIX_CERT_PEM_FILE);
-      if( SPIFFS.exists( BLUEMIX_CERT_PEM_FILE )) {
-        File pemfile = SPIFFS.open( BLUEMIX_CERT_PEM_FILE );
-        if( pemfile ) {
-          char *DownloadServerPemChain = nullptr;
-          size_t pemSize = pemfile.size();
-          DownloadServerPemChain = (char *)malloc(pemSize);
-          if( pemSize != pemfile.readBytes(DownloadServerPemChain, pemSize) ) {
-            Serial.printf("Reading %s pem server certificate chain failed.\r\n",BLUEMIX_CERT_PEM_FILE);
-          } else {
-            Serial.printf("Read %s pem server certificate chain from SPIFFS\r\n",BLUEMIX_CERT_PEM_FILE);
-            Serial.write((const unsigned char*)DownloadServerPemChain,pemSize);
-
-            // Increase the watchdog timer before starting the firmware upgrade
-            // The download and write can trip the watchdog timer and the old firmware
-            // will abort / reset before the new firmware is complete.
-            esp_task_wdt_init(15,0);
-            NeoPixelStatus( LED_OFF ); // turn off the LED to reduce power consumption
-            WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detector
-
-            Serial.println("Starting OpenEEW OTA firmware upgrade...");
-            esp_http_client_config_t config = {0};
-            config.url = firmware_ota_url.c_str() ;
-            config.cert_pem = DownloadServerPemChain ;
-            esp_err_t ret = esp_https_ota(&config);
-            if (ret == ESP_OK) {
-                Serial.println("OTA upgrade downloaded. Restarting...");
-                WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 1); //enable brownout detector
-                esp_restart();
-            } else {
-                esp_task_wdt_init(5,0);
-                Serial.println("The OpenEEW OTA firmware upgrade failed : ESP_FAIL");
-            }
-          }
-          free( DownloadServerPemChain );
-        } else {
-          Serial.println("Failed to open server pem chain.");
-        }
-        pemfile.close();
-      } else {
-        Serial.printf("The %s pem server certificate file does not exist.\r\n",BLUEMIX_CERT_PEM_FILE);
-        Serial.println("The SPIFFS filesystem might be empty.");
-      }
-    } else {
-      Serial.println("An error has occurred while mounting SPIFFS");
-    }
-  }
-  // Free allocated memory when we're done
-  semver_free(&current_version);
-  semver_free(&latest_version);
-  return true;
-}
-
-
 bool FirmwareVersionCheck( char *firmware_latest, String firmware_ota_url ) {
   semver_t current_version = {};
   semver_t latest_version = {};
@@ -480,17 +390,23 @@ bool FirmwareVersionCheck( char *firmware_latest, String firmware_ota_url ) {
     NeoPixelStatus( LED_FIRMWARE_OTA ); // blink magenta
 
     if( SPIFFS.begin(false) ) {
-      Serial.printf("Opening Server PEM Chain : %s\r\n", DOWNLOAD_CERT_PEM_FILE);
-      if( SPIFFS.exists( DOWNLOAD_CERT_PEM_FILE )) {
-        File pemfile = SPIFFS.open( DOWNLOAD_CERT_PEM_FILE );
+      char DownloadServerCert[30];
+      if( firmware_ota_url.indexOf("mybluemix.net") >=0 ) {
+        strncpy(DownloadServerCert, BLUEMIX_CERT_PEM_FILE,  30);
+      } else {
+        strncpy(DownloadServerCert, DOWNLOAD_CERT_PEM_FILE, 30);
+      }
+      Serial.printf("Opening Server PEM Chain : %s\r\n", DownloadServerCert);
+      if( SPIFFS.exists( DownloadServerCert )) {
+        File pemfile = SPIFFS.open( DownloadServerCert );
         if( pemfile ) {
           char *DownloadServerPemChain = nullptr;
           size_t pemSize = pemfile.size();
           DownloadServerPemChain = (char *)malloc(pemSize);
           if( pemSize != pemfile.readBytes(DownloadServerPemChain, pemSize) ) {
-            Serial.printf("Reading %s pem server certificate chain failed.\r\n",DOWNLOAD_CERT_PEM_FILE);
+            Serial.printf("Reading %s pem server certificate chain failed.\r\n",DownloadServerCert);
           } else {
-            Serial.printf("Read %s pem server certificate chain from SPIFFS\r\n",DOWNLOAD_CERT_PEM_FILE);
+            Serial.printf("Read %s pem server certificate chain from SPIFFS\r\n",DownloadServerCert);
             Serial.write((const unsigned char*)DownloadServerPemChain,pemSize);
 
             // Increase the watchdog timer before starting the firmware upgrade
@@ -520,7 +436,7 @@ bool FirmwareVersionCheck( char *firmware_latest, String firmware_ota_url ) {
         }
         pemfile.close();
       } else {
-        Serial.printf("The %s pem server certificate file does not exist.\r\n",DOWNLOAD_CERT_PEM_FILE);
+        Serial.printf("The %s pem server certificate file does not exist.\r\n",DownloadServerCert);
         Serial.println("The SPIFFS filesystem might be empty.");
       }
     } else {
@@ -589,11 +505,7 @@ bool OpenEEWDeviceActivation() {
 
       strncpy(firmware_latest, ActivationData["firmware_latest"], sizeof(firmware_latest) );
       firmware_ota_url = ActivationData["firmware_ota_url"].as<String>();
-      if( firmware_ota_url.indexOf("mybluemix.net") >=0 ) {
-        LegacyFirmwareVersionCheck(firmware_latest, firmware_ota_url);
-      } else {
-        FirmwareVersionCheck(firmware_latest, firmware_ota_url);
-      }
+      FirmwareVersionCheck(firmware_latest, firmware_ota_url);
     }
     return true ;
   } else {        // Failed to successfully contact endpoint


### PR DESCRIPTION
I am skeptical about reading the download.openeew.com server certificate from SPIFFS
In the case of v1.4.0, the download.openeew.com PEM file not in the SPIFFS data partition. (40 of these devices are in Puerto Rico)
When the download server certificate is renewed, we haven't tested whether the PEM changes.
v1.5.1 embeds the download.openeew.com server certificate PEM file inside the firmware.
It tries to read it from SPIFFS but if that fails for any reason, it falls back to the inline version.
I'm merging/releasing v1.5.1 so that the firmware binary can be staged on download.openeew.com and mybluemix.net.